### PR TITLE
Update for Stardew Valley 1.3.32 and SMAPI 2.8

### DIFF
--- a/PartOfTheCommunity/ModEntry.cs
+++ b/PartOfTheCommunity/ModEntry.cs
@@ -69,12 +69,12 @@ namespace SB_PotC
         *********/
         private void SaveConfigFile(object sender, EventArgs e)
         {
-            this.Helper.WriteJsonFile($"{Constants.SaveFolderName}/config.json", this.Config);
+            this.Helper.Data.WriteJsonFile($"{Constants.SaveFolderName}/config.json", this.Config);
         }
 
         private void SetVariables(object sender, EventArgs e)
         {
-            this.Config = this.Helper.ReadJsonFile<ModConfig>($"{Constants.SaveFolderName}/config.json") ?? new ModConfig();
+            this.Config = this.Helper.Data.ReadJsonFile<ModConfig>($"{Constants.SaveFolderName}/config.json") ?? new ModConfig();
             foreach (string name in Game1.player.friendshipData.Keys)
             {
                 this.CheckRelationshipData(name);

--- a/PartOfTheCommunity/ModEntry.cs
+++ b/PartOfTheCommunity/ModEntry.cs
@@ -330,8 +330,8 @@ namespace SB_PotC
                     }
                     this.WitnessCount[name][1] = 0;
                     this.WitnessCount[name][3] = 0;
-                }
-                if (((Game1.player.isMarried() && Game1.player.spouse == name) || (Game1.getCharacterFromName(name) is Child child && child.isChildOf(Game1.player))) && this.WitnessCount[name][0] == 1)
+				}
+				if (((Game1.player.isMarried() && Game1.player.spouse == name) || (Game1.getCharacterFromName(name) is Child child && child.idOfParent == Game1.player.UniqueMultiplayerID)) && this.WitnessCount[name][0] == 1)
                 {
                     foreach (string relation in this.CharacterRelationships[name].Keys.ToArray())
                     {
@@ -538,7 +538,7 @@ namespace SB_PotC
                 }
 
                 //Check for Relationships of your children
-                if (Game1.getCharacterFromName(name) is Child child && child.isChildOf(Game1.player))
+				if (Game1.getCharacterFromName(name) is Child child && child.idOfParent == Game1.player.UniqueMultiplayerID)
                 {
                     CheckRelationshipData(Game1.player.spouse);
                     this.CharacterRelationships[name].Add(Game1.player.spouse, Utility.isMale(Game1.player.spouse) ? "Father" : "Mother");

--- a/PartOfTheCommunity/PartOfTheCommunity.csproj
+++ b/PartOfTheCommunity/PartOfTheCommunity.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>PartOfTheCommunity</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <ModFolderName>SB_PotC</ModFolderName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,7 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -43,18 +44,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="manifest.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Include="manifest.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
-    <PropertyGroup>
-      <ModPath>$(GamePath)\Mods\SB_PotC</ModPath>
-    </PropertyGroup>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
-  </Target>
 </Project>

--- a/PartOfTheCommunity/PartOfTheCommunity.csproj
+++ b/PartOfTheCommunity/PartOfTheCommunity.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -46,6 +47,9 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
     <PropertyGroup>
@@ -56,11 +60,11 @@
     <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
   </Target>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/PartOfTheCommunity/PartOfTheCommunity.csproj
+++ b/PartOfTheCommunity/PartOfTheCommunity.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,8 +11,6 @@
     <AssemblyName>PartOfTheCommunity</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -45,7 +46,6 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
@@ -57,5 +57,4 @@
     <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
   </Target>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
 </Project>

--- a/PartOfTheCommunity/PartOfTheCommunity.csproj
+++ b/PartOfTheCommunity/PartOfTheCommunity.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -47,9 +47,6 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
     <PropertyGroup>
@@ -60,11 +57,5 @@
     <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
   </Target>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
 </Project>

--- a/PartOfTheCommunity/manifest.json
+++ b/PartOfTheCommunity/manifest.json
@@ -5,9 +5,9 @@
     "MajorVersion": 1,
     "MinorVersion": 1,
     "PatchVersion": 5,
-    "Build": "unofficial.1-Mizzion"
+    "Build": "unofficial.2-jo"
   },
   "Description": "Lets you increase friendship by supporting the community.",
   "UniqueID": "SB_PotC",
-  "EntryDll": "PartOfTheCommunity.dll"
+  "EntryDll": "PartOfTheCommunity.dll",
 }

--- a/PartOfTheCommunity/manifest.json
+++ b/PartOfTheCommunity/manifest.json
@@ -1,13 +1,10 @@
 {
   "Name": "Part of the Community",
   "Author": "Brandon Marquis Markail Green (Space Baby)",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 1,
-    "PatchVersion": 5,
-    "Build": "unofficial.2-jo"
-  },
+  "Version": "1.1.4",
   "Description": "Lets you increase friendship by supporting the community.",
   "UniqueID": "SB_PotC",
   "EntryDll": "PartOfTheCommunity.dll",
+  "MinimumApiVersion": "2.8",
+  "UpdateKeys": [ "Nexus:923" ]
 }

--- a/PartOfTheCommunity/manifest.json
+++ b/PartOfTheCommunity/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Part of the Community",
   "Author": "Brandon Marquis Markail Green (Space Baby)",
-  "Version": "1.1.4",
+  "Version": "1.1.5",
   "Description": "Lets you increase friendship by supporting the community.",
   "UniqueID": "SB_PotC",
   "EntryDll": "PartOfTheCommunity.dll",

--- a/PartOfTheCommunity/manifest.json
+++ b/PartOfTheCommunity/manifest.json
@@ -4,8 +4,8 @@
   "Version": {
     "MajorVersion": 1,
     "MinorVersion": 1,
-    "PatchVersion": 3,
-    "Build": null
+    "PatchVersion": 5,
+    "Build": "unofficial.1-Mizzion"
   },
   "Description": "Lets you increase friendship by supporting the community.",
   "UniqueID": "SB_PotC",

--- a/PartOfTheCommunity/packages.config
+++ b/PartOfTheCommunity/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0" targetFramework="net45" />
-</packages>

--- a/PartOfTheCommunity/packages.config
+++ b/PartOfTheCommunity/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180428" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/PartOfTheCommunity/packages.config
+++ b/PartOfTheCommunity/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.5.0" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180428" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This pull request...

* Updates the code for Stardew Valley 1.3.32 and SMAPI 2.8 (including the changes from #2 and #3).
* Updates the `manifest.json` to enable update checks and standardise the version format.
* Migrates to the new NuGet package reference format and simplifies the project file.
* Fixes errors when the player hasn't met an NPC yet.

If these changes look fine, can you deploy [PartOfTheCommunity 1.1.5.zip](https://github.com/bmarquismarkail/SV_PotC/files/2609403/PartOfTheCommunity.1.1.5.zip) to the [Nexus mod page](https://www.nexusmods.com/stardewvalley/mods/923)? 